### PR TITLE
fix: add the libc in order to turn glauth server back normal

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,6 +27,11 @@ parts:
     stage:
       - etc/config/glauth.cfg
 
+  libc:
+    plugin: nil
+    stage-packages:
+      - libc6_libs
+
   glauth:
     plugin: make
     build-snaps:


### PR DESCRIPTION
This pull request tries to resolve the https://github.com/canonical/glauth-rock/issues/90.

The issue is likely due to the fact that we removed some utils from the image a while ago. And the GitHub image publishing workflow was not working normally for a while, so we did not find this problem in time.

Definitely we need some auto mechanism to test the published image with the corresponding consumer charm.