### PR TITLE
ci: fix the oci-factory rock publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,6 @@ on:
   push:
     branches:
       - "main"
-      - "release-**"
-    tags:
-      - "v**"
     paths:
       - "rockcraft.yaml"
       - ".github/workflows/**.yaml"
@@ -27,14 +24,13 @@ jobs:
     with:
       structure-tests-enabled: true
   gh-publish:
-    if: ${{ (github.ref == 'refs/heads/main') || (github.ref_type == 'tag') }}
+    if: github.ref == 'refs/heads/main'
     needs: build
     uses: canonical/identity-team/.github/workflows/_rock-gh-publish.yaml@f18247249f506f3c9210b86e43a2c4dd063088c5 # v1.8.7
     with:
       rock: ${{ needs.build.outputs.rock }}
   oci-publish:
-    # only release to oci-factory in case of release
-    if: github.ref_type == 'tag'
+    if: github.ref == 'refs/heads/main'
     needs: build
     uses: canonical/identity-team/.github/workflows/_rock-oci-publish.yaml@f18247249f506f3c9210b86e43a2c4dd063088c5 # v1.8.7
     with:
@@ -43,14 +39,14 @@ jobs:
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
   scan:
-    if: ${{ (github.ref == 'refs/heads/main') || (github.ref_type == 'tag') }}
+    if: github.ref == 'refs/heads/main'
     needs: gh-publish
     uses: canonical/identity-team/.github/workflows/_rock-scan.yaml@f18247249f506f3c9210b86e43a2c4dd063088c5 # v1.8.7
     with:
       image: ${{ needs.gh-publish.outputs.image }}
   oci-update-pr:
     needs: [gh-publish, scan]
-    if: github.ref_type == 'tag'
+    if: github.ref == 'refs/heads/main'
     uses: canonical/identity-team/.github/workflows/oci-update-pr.yaml@f18247249f506f3c9210b86e43a2c4dd063088c5 # v1.8.7
     with:
         oci-image: ${{ needs.gh-publish.outputs.image }}


### PR DESCRIPTION
This pull request aims to fix the oci-factory rock publishing job. It will do a oci-factory publish on `main` branch since there is no tag release strategy for the glauth currently.